### PR TITLE
問題結果画面作りました

### DIFF
--- a/frontengine/src/App.vue
+++ b/frontengine/src/App.vue
@@ -2,6 +2,7 @@
   <div id="app">
     <Header></Header>
     <div id="nav">
+      <router-link to="/problemResult">ProblemResult</router-link>
     </div>
     <router-view/>
   </div>

--- a/frontengine/src/components/Header.vue
+++ b/frontengine/src/components/Header.vue
@@ -3,7 +3,7 @@
   <b-navbar toggleable="lg" type="dark" variant="info">>
     <b-navbar-brand to="/">front Engine</b-navbar-brand>
     <div class="menu">
-    <b-navbar-brand class="examList" to="/ProblemDetail">examList</b-navbar-brand>
+    <b-navbar-brand class="examList" to="/ProblemList">examList</b-navbar-brand>
     </div>
     <b-navbar-nav class="ml-auto">
       <b-nav-item class="email"> {{ getEmail }}</b-nav-item>

--- a/frontengine/src/components/OutputCard.vue
+++ b/frontengine/src/components/OutputCard.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="b-card">
+    <b-card bg-variant="white" text-variant="black" class="text-center">
+      <b-card-header header-bg-variant="warning">
+        <b-card-text>期待される出力：{{expectation}}</b-card-text>
+      </b-card-header>
+      <b-card-body>
+        <b-card-text>あなたの出力：{{yourAnswer}}</b-card-text>
+      </b-card-body>
+    </b-card>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'OutputCard',
+  props: {
+    expectation: String,
+    yourAnswer: String
+  }
+}
+</script>
+
+<style scoped>
+.b-card {
+  margin: 40px 40px 40px;
+}
+</style>

--- a/frontengine/src/components/ResultCard.vue
+++ b/frontengine/src/components/ResultCard.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="b-card">
+    <b-card bg-variant="white" text-variant="black" class="text-center">
+      <b-card-header header-bg-variant="warning">
+        <b-card-text>テストケースNo.{{testCaseNumber}}</b-card-text>
+      </b-card-header>
+      <b-card-body>
+        <b-card-text>{{judgment}}</b-card-text>
+      </b-card-body>
+    </b-card>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ResultCard',
+  props: {
+    testCaseNumber: String,
+    judgment: String
+  }
+}
+</script>
+
+<style scoped>
+.b-card {
+  margin: 40px 40px 40px;
+}
+</style>

--- a/frontengine/src/router/index.js
+++ b/frontengine/src/router/index.js
@@ -4,6 +4,7 @@ import Home from '../views/Home.vue'
 import ProblemList from '@/views/ProblemList.vue'
 import ProblemDetail from '@/views/ProblemDetail.vue'
 import Entry from '@/views/Entry.vue'
+import ProblemResult from '@/views/ProblemResult.vue'
 Vue.use(VueRouter)
 
 const routes = [
@@ -29,6 +30,11 @@ const routes = [
     path: '/entry',
     name: 'Entry',
     component: Entry
+  },
+  {
+    path: '/problemResult',
+    name: 'ProblemResult',
+    component: ProblemResult
   }
 ]
 

--- a/frontengine/src/views/ProblemResult.vue
+++ b/frontengine/src/views/ProblemResult.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="problemResult">
+    <h1>結果</h1>
+    <h3>今回の結果はこちら</h3>
+    <b-container class="bv-example-row">
+      <b-row cols="2" cols-sm="1" cols-md="1" cols-lg="2">
+        <b-col>
+          <ul id="example-1">
+            <ResultCard v-for="(item, index) in result" :key="index" :testCaseNumber="item.number" :judgment="item.message"/>
+          </ul>
+        </b-col>
+        <b-col>
+          <ul id="example-2">
+            <OutputCard v-for="(item, index) in output" :key="index" :expectation="item.expectations" :yourAnswer="item.answer"/>
+          </ul>
+        </b-col>
+      </b-row>
+    </b-container>
+  </div>
+</template>
+
+<script>
+// @ is an alias to /src
+// import firebase from 'firebase'
+// import { mapActions, mapGetters } from 'vuex'
+import ResultCard from '@/components/ResultCard.vue'
+import OutputCard from '@/components/OutputCard.vue'
+
+export default {
+  name: 'ProblemResult',
+  components: {
+    ResultCard,
+    OutputCard
+  },
+  data () {
+    return {
+      result: [
+        { number: '1', message: '正解' },
+        { number: '2', message: '正解' },
+        { number: '3', message: '不正解' },
+        { number: '4', message: '正解' },
+        { number: '5', message: '不正解' },
+        { number: '6', message: '不正解' },
+        { number: '7', message: '正解' },
+        { number: '8', message: '不正解' },
+        { number: '9', message: '正解' },
+        { number: '10', message: '正解' }
+      ],
+      output: [
+        { expectations: 'hello', answer: 'hello' },
+        { expectations: 'hello world', answer: 'helloworld' },
+        { expectations: 'HELLO', answer: '' },
+        { expectations: 'HELLO WORLD', answer: 'HELLOWORLD' },
+        { expectations: 'Hello', answer: '' },
+        { expectations: 'HelloWorld', answer: '' },
+        { expectations: 'Helloworld', answer: 'Helloworld' },
+        { expectations: 'HELLOworld', answer: '' },
+        { expectations: 'helloWORLD', answer: 'helloWORLD' },
+        { expectations: 'goodbye', answer: 'goodbye' }
+      ]
+    }
+  }
+}
+</script>


### PR DESCRIPTION
問題詳細画面で回答送信後に遷移する予定の問題結果画面を作成しました。テストケースなど表示方法がわからないためダミーデータをカードに入れてあります。
現在は遷移方法がないためApp.vueで画面上部の「ProblemResult」を押すことで遷移できるようにしてあります。